### PR TITLE
Interface agreement fixes: done pulse and 32-row termination

### DIFF
--- a/src/uart_fsm.vhd
+++ b/src/uart_fsm.vhd
@@ -3,8 +3,8 @@
 -- Description: FSM controller — FIFO to RAM writer
 --   Reads bytes from the RX FIFO one at a time, packs
 --   4 consecutive bytes into a 32-bit word, then writes
---   the word to RAM. Asserts fsm_done when the FIFO is
---   fully drained and the last complete word is written.
+--   the word to RAM. Issues a single-cycle fsm_done pulse
+--   after row 31 (the 32nd word) is written.
 --   Packing: byte 0 -> bits [7:0],  byte 1 -> bits [15:8],
 --            byte 2 -> bits [23:16], byte 3 -> bits [31:24]
 -- Author: Alberto Hernandez
@@ -28,15 +28,18 @@ entity uart_fsm is
         ram_addr   : out std_logic_vector(4 downto 0);     -- row address (0-31)
         ram_din    : out std_logic_vector(31 downto 0);    -- 32-bit packed word to write
         -- status
-        fsm_done   : out std_logic                         -- HIGH when FIFO is fully drained
+        fsm_done   : out std_logic                         -- single-cycle pulse after row 31 written
     );
 end uart_fsm;
 
 architecture arch of uart_fsm is
 
     -- FSM states
-    type state_type is (IDLE, READ_BYTE, PACK, WRITE_RAM, DONE);
+    type state_type is (IDLE, READ_BYTE, PACK, WRITE_RAM, DONE_PULSE, DONE);
     signal state, state_next : state_type;
+
+    -- row 31 is the last valid RAM address (32 rows total)
+    constant MAX_ADDR : unsigned(4 downto 0) := to_unsigned(31, 5);
 
     -- captures the byte from the FIFO in READ_BYTE so it is stable in PACK
     -- the FIFO advances its pointer one clock after fifo_rd, so fifo_dout
@@ -90,12 +93,9 @@ begin
         case state is
 
             -- IDLE: wait for data in the FIFO
-            -- if FIFO is empty and no partial word is in progress, all bytes are written
             when IDLE =>
                 if fifo_empty = '0' then
                     state_next <= READ_BYTE;
-                elsif byte_idx = 0 then
-                    state_next <= DONE;
                 end if;
 
             -- READ_BYTE: fifo_dout already holds a valid byte (FWFT FIFO)
@@ -127,13 +127,23 @@ begin
             -- ram_din defaults to word_reg which already holds all 4 packed bytes
             when WRITE_RAM =>
                 ram_we        <= '1';
-                addr_next     <= addr_reg + 1;
                 byte_idx_next <= (others => '0');
-                state_next    <= IDLE;
+                if addr_reg = MAX_ADDR then
+                    -- row 31 written: signal completion next cycle
+                    state_next <= DONE_PULSE;
+                else
+                    addr_next  <= addr_reg + 1;
+                    state_next <= IDLE;
+                end if;
 
-            -- DONE: hold fsm_done HIGH until reset
+            -- DONE_PULSE: assert fsm_done for exactly one clock cycle
+            when DONE_PULSE =>
+                fsm_done   <= '1';
+                state_next <= DONE;
+
+            -- DONE: all rows written, stay idle
             when DONE =>
-                fsm_done <= '1';
+                null;
 
         end case;
     end process;

--- a/tb/tb_classification_engine.vhd
+++ b/tb/tb_classification_engine.vhd
@@ -92,7 +92,6 @@ architecture sim of tb_classification_engine is
     -- -------------------------------------------------------------------------
     -- Tracking variables
     -- -------------------------------------------------------------------------
-    signal row_index   : integer := 0;
     signal pass_count  : integer := 0;
     signal fail_count  : integer := 0;
  
@@ -109,7 +108,9 @@ begin
     process(clk)
     begin
         if rising_edge(clk) then
-            ram_dout <= ram_mem(to_integer(unsigned(ram_addr)));
+            if not is_x(ram_addr) then
+                ram_dout <= ram_mem(to_integer(unsigned(ram_addr)));
+            end if;
         end if;
     end process;
  
@@ -179,10 +180,14 @@ begin
         end loop;
  
         -- ---------------------------------------------------------------------
-        -- 4. Wait for done pulse
+        -- 4. Wait for done pulse and verify it is exactly one cycle wide
         -- ---------------------------------------------------------------------
         wait until rising_edge(clk) and done = '1';
         report "done signal asserted -- classification complete.";
+        wait until rising_edge(clk);
+        assert done = '0'
+            report "done pulse FAILED: done did not deassert after one cycle"
+            severity error;
  
         -- ---------------------------------------------------------------------
         -- 5. Final summary

--- a/tb/tb_uart_fsm.vhd
+++ b/tb/tb_uart_fsm.vhd
@@ -2,10 +2,11 @@
 -- Testbench: tb_uart_fsm
 -- Description: Verifies the FSM reads bytes from the
 --   FIFO and writes 32-bit packed words to RAM correctly.
---   Pre-loads 8 bytes into a FWFT FIFO model (2 RAM words).
+--   Pre-loads 128 bytes into a FWFT FIFO model (32 RAM words).
 --   Expected results:
---     RAM[0] = 0xA4A3A2A1  (bytes A1,A2,A3,A4 packed little-endian)
---     RAM[1] = 0xB4B3B2B1  (bytes B1,B2,B3,B4 packed little-endian)
+--     RAM[0]  = 0xA4A3A2A1  (bytes A1,A2,A3,A4 packed little-endian)
+--     RAM[1]  = 0xB4B3B2B1  (bytes B1,B2,B3,B4 packed little-endian)
+--     RAM[31] = 0xE4E3E2E1  (bytes E1,E2,E3,E4 packed little-endian)
 -- Author: Alberto Hernandez
 -- Date: 2026-04-14
 -- ============================================
@@ -32,15 +33,21 @@ architecture sim of tb_uart_fsm is
 
     constant CLK_PERIOD : time := 10 ns;  -- 100 MHz
 
-    -- FIFO model: 8 pre-loaded bytes, FWFT behavior
+    -- FIFO model: 128 pre-loaded bytes (32 words), FWFT behavior
     -- r_data (fifo_dout) is valid whenever empty is LOW
     -- asserting fifo_rd advances the read pointer on the next rising edge
-    type fifo_mem_t is array (0 to 7) of std_logic_vector(7 downto 0);
+    type fifo_mem_t is array (0 to 127) of std_logic_vector(7 downto 0);
     constant FIFO_DATA : fifo_mem_t := (
+        -- Row 0: bytes A1..A4  -> RAM[0] = 0xA4A3A2A1
         0 => x"A1", 1 => x"A2", 2 => x"A3", 3 => x"A4",
-        4 => x"B1", 5 => x"B2", 6 => x"B3", 7 => x"B4"
+        -- Row 1: bytes B1..B4  -> RAM[1] = 0xB4B3B2B1
+        4 => x"B1", 5 => x"B2", 6 => x"B3", 7 => x"B4",
+        -- Rows 2-30: all zero  -> RAM[2..30] = 0x00000000
+        8 to 123 => x"00",
+        -- Row 31: bytes E1..E4 -> RAM[31] = 0xE4E3E2E1
+        124 => x"E1", 125 => x"E2", 126 => x"E3", 127 => x"E4"
     );
-    signal rd_ptr : integer range 0 to 8 := 0;
+    signal rd_ptr : integer range 0 to 128 := 0;
 
     -- RAM model: 32 rows x 32-bit, matches ram_module interface
     type ram_mem_t is array (0 to 31) of std_logic_vector(31 downto 0);
@@ -66,8 +73,8 @@ begin
     clk <= not clk after CLK_PERIOD / 2;
 
     -- FWFT FIFO model: r_data always shows the current head byte
-    fifo_dout  <= FIFO_DATA(rd_ptr) when rd_ptr < 8 else (others => '0');
-    fifo_empty <= '1' when rd_ptr >= 8 else '0';
+    fifo_dout  <= FIFO_DATA(rd_ptr) when rd_ptr < 128 else (others => '0');
+    fifo_empty <= '1' when rd_ptr >= 128 else '0';
 
     -- advance the read pointer when the FSM pops a byte
     fifo_proc: process(clk, reset)
@@ -75,7 +82,7 @@ begin
         if reset = '1' then
             rd_ptr <= 0;
         elsif rising_edge(clk) then
-            if fifo_rd = '1' and rd_ptr < 8 then
+            if fifo_rd = '1' and rd_ptr < 128 then
                 rd_ptr <= rd_ptr + 1;
             end if;
         end if;
@@ -99,8 +106,8 @@ begin
         wait for 100 ns;
         reset <= '0';
 
-        -- wait for the FSM to drain the FIFO and signal completion
-        wait until fsm_done = '1';
+        -- wait for the FSM to signal completion (single-cycle pulse)
+        wait until rising_edge(clk) and fsm_done = '1';
         wait for CLK_PERIOD;
 
         -- TEST 1: first 4 bytes (A1,A2,A3,A4) packed little-endian into RAM[0]
@@ -116,6 +123,13 @@ begin
                    integer'image(to_integer(unsigned(ram_mem(1))))
             severity error;
         report "TEST 2 PASSED: RAM[1] = 0xB4B3B2B1" severity note;
+
+        -- TEST 3: last 4 bytes (E1,E2,E3,E4) packed little-endian into RAM[31]
+        assert ram_mem(31) = x"E4E3E2E1"
+            report "TEST 3 FAILED: RAM[31] expected 0xE4E3E2E1, got " &
+                   integer'image(to_integer(unsigned(ram_mem(31))))
+            severity error;
+        report "TEST 3 PASSED: RAM[31] = 0xE4E3E2E1" severity note;
 
         report "All FSM tests complete" severity note;
         wait;


### PR DESCRIPTION
- `uart_fsm`: replace level-high done with a single-cycle `fsm_done` pulse after row 31 is written; add `MAX_ADDR` constant and `DONE_PULSE` state; remove early FIFO-empty exit
- `tb_uart_fsm`: expand FIFO model to 128 bytes (32 words); wait on clock edge for done pulse; add assertion for RAM[31]
- `tb_classification_engine`: guard RAM model against uninitialized address bits; assert done deasserts after one cycle; remove unused signal
