### PR TITLE
Fix TX FIFO depth and testbench hang on dropped bytes

### DIFF
--- a/src/uart_top.vhd
+++ b/src/uart_top.vhd
@@ -191,6 +191,7 @@ begin
     -- TX FIFO  (classifier writes; TX controller reads)
     -- -------------------------------------------------------
     U_TX_FIFO : entity work.fifo
+        generic map(B => 8, W => 7)   -- 128 entries; holds all classification results without dropping
         port map(
             clk    => clk,
             reset  => reset,

--- a/tb/tb_uart_top.vhd
+++ b/tb/tb_uart_top.vhd
@@ -193,8 +193,15 @@ begin
         variable n_pass : integer := 0;
         variable n_fail : integer := 0;
     begin
-        -- wait for the very first start bit (TX falls from idle HIGH)
-        wait until falling_edge(tx);
+        -- Wait for first start bit. Generous timeout: 128 RX bytes at 9600 baud
+        -- takes ~133 ms before classification and TX begin.
+        wait until falling_edge(tx) for 400 ms;
+        if tx /= '0' then
+            report "TIMEOUT: no TX activity seen within 400 ms"
+                severity error;
+            tx_verify_done <= '1';
+            wait;
+        end if;
 
         for byte_idx in 0 to NUM_TX_BYTES - 1 loop
 
@@ -233,9 +240,19 @@ begin
                 n_fail := n_fail + 1;
             end if;
 
-            -- wait for start bit of next byte (TX controller has a few-cycle gap)
+            -- 2 ms inter-byte timeout: one byte at 9600 baud takes ~1.04 ms,
+            -- so 2 ms is safe. A hang here means bytes were dropped by DUT.
             if byte_idx < NUM_TX_BYTES - 1 then
-                wait until falling_edge(tx);
+                wait until falling_edge(tx) for 2 ms;
+                if tx /= '0' then
+                    report "TIMEOUT: TX stopped after byte " &
+                           integer'image(byte_idx) & "; " &
+                           integer'image(NUM_TX_BYTES - byte_idx - 1) &
+                           " bytes not received (check TX FIFO depth)"
+                        severity error;
+                    n_fail := n_fail + (NUM_TX_BYTES - byte_idx - 1);
+                    exit;
+                end if;
             end if;
 
         end loop;


### PR DESCRIPTION
## Problem
The classification engine runs at 100 MHz and produces all 128 `result_valid` pulses in ~224 clock cycles (~2.24 µs). The TX FIFO had depth 16 (W=4). At 9600 baud the TX controller drains ~1 byte/ms, so the FIFO fills and overflows instantly — results 16–127 were silently dropped. The testbench then blocked permanently on `wait until falling_edge(tx)` for a byte that never arrived.

## Fixes
- **`src/uart_top.vhd`**: Set TX FIFO depth to 128 (W=7, 2⁷ entries) via `generic map(B => 8, W => 7)`. The FIFO now holds all 128 classification results without dropping any.
- **`tb/tb_uart_top.vhd`**: Added bounded timeouts to both `wait until falling_edge(tx)` calls — 400 ms for the first byte, 2 ms per subsequent byte. If the DUT stops producing bytes early the testbench exits the loop, tallies the missing bytes as failures, and reports a deterministic result instead of hanging.