### PR TITLE
Fix TX FIFO generic name and ADDR_WIDTH for 128-byte capacity

### DIFF
--- a/src/uart_top.vhd
+++ b/src/uart_top.vhd
@@ -191,7 +191,7 @@ begin
     -- TX FIFO  (classifier writes; TX controller reads)
     -- -------------------------------------------------------
     U_TX_FIFO : entity work.fifo
-        generic map(B => 8, W => 7)   -- 128 entries; holds all classification results without dropping
+        generic map(ADDR_WIDTH => 8)   -- 255 usable slots (256 - 1 reserved); covers all 128 results
         port map(
             clk    => clk,
             reset  => reset,


### PR DESCRIPTION
## Problem
Two bugs in the TX FIFO instantiation in `uart_top.vhd`:

1. **Wrong generic names**: `fifo.vhd` uses `DATA_WIDTH`/`ADDR_WIDTH`; the previous commit used `B`/`W` (from the interface agreement spec, not the implementation). The named association would fail to elaborate.
2. **Insufficient depth**: The FIFO uses `ptr_inc(w_ptr_next) = r_ptr_next` as the full condition, reserving one slot to distinguish full from empty. `ADDR_WIDTH => 7` gives 2⁷ − 1 = 127 usable slots — one short of the 128 classifier outputs.

## Fix
Single-line change: `generic map(ADDR_WIDTH => 8)` — 2⁸ = 256 slots, 255 usable, covering all 128 results with margin. `DATA_WIDTH` is left at its default of 8.